### PR TITLE
fix: Correct NPM package name and fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ composer require --dev laravel/nova-devtool
 Once installed, you can run the following to update NPM's `package.json`:
 
 ```shell
-npm install --save-dev "vendor/laravel/nova-devtool"
+npm install --save-dev @laravel/nova-devtool
 ```
 
-## Usages
+## Usage
 
 ### Setup Laravel Nova Workbench
 
@@ -43,7 +43,7 @@ workbench:
 
 ### Install Axios, Lodash, Tailwind CSS or Vue
 
-To simplify the installation, you can run the following commnad:
+To simplify the installation, you can run the following command:
 
 ```shell
 php vendor/bin/testbench nova:devtool install


### PR DESCRIPTION
# Description

This PR improves the installation instructions in the README and cleans up some typos for clarity and consistency.

---

## Changes Made

  **Improved Installation Command**: Updated the NPM install command to use the official package identifier:

  ```shell
  # Previous (works, but less ideal)
  npm install --save-dev "vendor/laravel/nova-devtool"

  # Improved (recommended)
  npm install --save-dev @laravel/nova-devtool
 ```

Using the scoped package name @laravel/nova-devtool is clearer, more standard, and aligns with published NPM practices.

- Typo Fix: Corrected the spelling of "commnad" → "command".
- Consistency: Changed the section header from "Usages" → "Usage".

Impact

- ✅ Users now see the recommended installation method, reducing potential confusion.
- ✅ The documentation is clearer, more professional, and consistent.
